### PR TITLE
Statisk path for js fil

### DIFF
--- a/UKMusers.php
+++ b/UKMusers.php
@@ -57,7 +57,7 @@ class UKMusers extends Modul
     }
 
     public static function usersScripts() {
-        wp_enqueue_script('UKMusers_js', PLUGIN_PATH . '/UKMusers/UKMusers.js' );
+        wp_enqueue_script('UKMusers_js', str_replace('http://','https://', WP_PLUGIN_URL) . '/UKMusers/UKMusers.js' );
         static::scriptsandstyles();
     }
 

--- a/UKMusers.php
+++ b/UKMusers.php
@@ -57,7 +57,7 @@ class UKMusers extends Modul
     }
 
     public static function usersScripts() {
-        wp_enqueue_script('UKMusers_js', str_replace('http://','https://', WP_PLUGIN_URL) . '/UKMusers/UKMusers.js' );
+        wp_enqueue_script('UKMusers_js', PLUGIN_PATH . '/UKMusers/UKMusers.js' );
         static::scriptsandstyles();
     }
 

--- a/UKMusers.php
+++ b/UKMusers.php
@@ -57,7 +57,7 @@ class UKMusers extends Modul
     }
 
     public static function usersScripts() {
-        wp_enqueue_script('UKMusers_js', static::getPluginUrl() . '/UKMusers.js' );
+        wp_enqueue_script('UKMusers_js', static::getPluginUrl() . 'UKMusers.js' );
         static::scriptsandstyles();
     }
 

--- a/UKMusers.php
+++ b/UKMusers.php
@@ -57,7 +57,7 @@ class UKMusers extends Modul
     }
 
     public static function usersScripts() {
-        wp_enqueue_script('UKMusers_js', str_replace('http://','https://', WP_PLUGIN_URL) . '/UKMusers/UKMusers.js' );
+        wp_enqueue_script('UKMusers_js', static::getPluginUrl() . '/UKMusers.js' );
         static::scriptsandstyles();
     }
 


### PR DESCRIPTION
Bruker en final variable for å definere statisk path-en for å peke på resurser.

Deriverer fra: https://github.com/UKMNorge/UKMresources/issues/3

OBS: UKMconfig.inc.php er modifisert. Denne linjen er lagt til:
"# RESOURCES PLUGIN PATH
define('PLUGIN_PATH', 'https://' . UKM_HOSTNAME . '/wp-content/plugins/');"